### PR TITLE
Fix invalid name for timestamp field

### DIFF
--- a/src/models/Notes.js
+++ b/src/models/Notes.js
@@ -4,8 +4,8 @@ class Notes {
     this.title = props.title;
     this.body = props.body;
     this.tags = props.tags;
-    this.createAt = props.created_at;
-    this.updateAt = props.updated_at;
+    this.createdAt = props.createdAt;
+    this.updatedAt = props.updatedAt;
   }
 }
 


### PR DESCRIPTION
# Description

There is mistype name for the timestamp field. The database field is `createdAt` and `updatedAt`, but node js define it as `created_at` and `updated_at`.